### PR TITLE
Harden session-brief path containment against symlink escapes

### DIFF
--- a/lib/run.cjs
+++ b/lib/run.cjs
@@ -448,6 +448,14 @@ function artifactRootsForPhase(phase, roots) {
   return [roots.contaminatedRoot];
 }
 
+function resolveExistingPathWithinRoots(filePath, allowedRoots, label) {
+  const realPath = fs.realpathSync(filePath);
+  if (!pathIsUnderAny(realPath, allowedRoots)) {
+    throw new Error(`${label} must resolve under allowed roots: ${filePath}`);
+  }
+  return realPath;
+}
+
 function resolveStageBriefPath(stage, configDir, roots) {
   const rawPath = stage.context?.brief_path;
   if (typeof rawPath !== 'string' || rawPath === '') {
@@ -457,6 +465,9 @@ function resolveStageBriefPath(stage, configDir, roots) {
   const allowedRoots = briefRootsForPhase(stage.phase, roots);
   if (!pathIsUnderAny(briefPath, allowedRoots)) {
     throw new Error(`agent command stage context.brief_path for ${stage.phase} must resolve under its artifact root`);
+  }
+  if (fs.existsSync(briefPath)) {
+    resolveExistingPathWithinRoots(briefPath, allowedRoots, `agent command stage context.brief_path for ${stage.phase}`);
   }
   return briefPath;
 }
@@ -1010,6 +1021,7 @@ function resolveAllowedArtifactRefPath(rawPath, allowedRoots) {
     : allowedRoots.map((root) => path.resolve(root, rawPath));
   for (const candidate of candidates) {
     if (pathIsUnderAny(candidate, allowedRoots) && fs.existsSync(candidate)) {
+      resolveExistingPathWithinRoots(candidate, allowedRoots, 'role-session brief artifact path');
       return candidate;
     }
   }
@@ -1040,6 +1052,7 @@ function validateBriefArtifactRefs(stage, roots, brief, budgets) {
       }
       throw new Error(`role-session brief artifact not found: ${artifact.path}`);
     }
+    resolveExistingPathWithinRoots(artifactPath, allowedRoots, `role-session brief artifact path ${artifact.path}`);
     const stat = fs.statSync(artifactPath);
     if (!stat.isFile()) {
       throw new Error(`role-session brief artifact is not a file: ${artifact.path}`);
@@ -1085,6 +1098,7 @@ function prepareStageSessionContext(python, stage, configDir, roots, manifest, u
   if (!fs.existsSync(briefPath)) {
     throw new Error(`role-session brief not found: ${briefPath}`);
   }
+  resolveExistingPathWithinRoots(briefPath, briefRootsForPhase(stage.phase, roots), `role-session brief for ${stage.phase}`);
   const budgets = manifest.context_management?.budgets || null;
   const briefText = fs.readFileSync(briefPath, 'utf8');
   if (budgets && briefText.length > budgets.max_brief_chars) {


### PR DESCRIPTION
### Motivation
- Close a symlink/TOCTOU boundary bypass where lexical-only containment checks allowed a symlink placed under an allowed root to point outside that root and expose contaminated data to clean roles.

### Description
- Add `resolveExistingPathWithinRoots(filePath, allowedRoots, label)` which uses `fs.realpathSync()` and enforces realpath containment with `pathIsUnderAny`.
- Enforce realpath containment for `context.brief_path` when the referenced path exists, retaining the original lexical checks but rejecting symlink targets outside allowed roots.
- Enforce realpath containment for candidate artifact paths in `resolveAllowedArtifactRefPath()` before accepting a candidate, and again before `stat()`/hashing in `validateBriefArtifactRefs()`.
- Enforce realpath containment before reading/validating the brief in `prepareStageSessionContext()` to close the consumption-time escape.
- Change is confined to `lib/run.cjs` and preserves existing lexical resolution behavior while adding realpath verification for existing files.

### Testing
- Ran `node --check lib/run.cjs bin/install.js` and it completed successfully.
- Attempted `node --test tests/run.test.js` (and `npm test` in this environment) but the test run timed out / was interrupted and did not complete; no test failures were observed prior to the timeout in the local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1302199be08326bb26820291a0e67d)