### PR TITLE
Reject symlinked bootstrap task roots during preflight validation

### DIFF
--- a/lib/bootstrap.cjs
+++ b/lib/bootstrap.cjs
@@ -263,6 +263,20 @@ function validateBootstrapScaffold(taskRoot) {
     throw new Error('bootstrap path requires a task root');
   }
   const outputRoot = path.resolve(taskRoot);
+  const outputRootStat = lstatIfExists(outputRoot);
+  if (!outputRootStat) {
+    throw new Error(`bootstrap scaffold is invalid:
+  bootstrap task root missing: ${outputRoot}`);
+  }
+  if (outputRootStat.isSymbolicLink()) {
+    throw new Error(`bootstrap scaffold is invalid:
+  bootstrap task root must not be a symbolic link: ${outputRoot}`);
+  }
+  if (!outputRootStat.isDirectory()) {
+    throw new Error(`bootstrap scaffold is invalid:
+  bootstrap task root is not a directory: ${outputRoot}`);
+  }
+
   const metadataPath = assertManagedPath(outputRoot, BOOTSTRAP_METADATA_FILE);
   requireFileOrThrow(metadataPath, 'bootstrap metadata');
 

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -615,6 +615,29 @@ describe('clean-room-skill installer', () => {
     assert.equal(fs.existsSync(path.join(taskRoot, 'contaminated', 'preflight-goal.json')), false);
   });
 
+
+  test('preflight rejects symlinked bootstrap task root', () => {
+    const root = tempDir('clean-room-preflight-bootstrap-symlink');
+    const targetDir = path.join(root, 'repo');
+    const artifactBase = path.join(root, 'artifacts');
+    const realTaskRoot = path.join(root, 'real-task-root');
+    const symlinkTaskRoot = path.join(artifactBase, 'task-bootstrap-symlink');
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.mkdirSync(path.dirname(symlinkTaskRoot), { recursive: true });
+
+    const init = runInstall(['init', '--target-dir', targetDir, '--artifact-base', root, '--task-id', 'real-task-root']);
+    assert.equal(init.status, 0, init.stderr);
+
+    fs.symlinkSync(realTaskRoot, symlinkTaskRoot, 'dir');
+
+    const result = runInstall(['preflight', '--template', '--bootstrap', symlinkTaskRoot]);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /bootstrap scaffold is invalid/);
+    assert.match(result.stderr, /bootstrap task root must not be a symbolic link/);
+    assert.equal(fs.existsSync(path.join(realTaskRoot, 'contaminated', 'preflight-goal.json')), false);
+  });
+
   test('preflight rejects bootstrap and output together', () => {
     const root = tempDir('clean-room-preflight-bootstrap-output');
     const output = path.join(root, 'preflight-goal.json');


### PR DESCRIPTION
### Motivation
- Prevent a symlink-based path-redirection where a crafted bootstrap task root could pass lexical checks and cause `preflight-goal.json` to be written into the symlink target, breaking trust separation.
- Harden bootstrap validation to ensure preflight output always stays under an actual generated task root and not an attacker-controlled symlink target.

### Description
- `validateBootstrapScaffold()` now lstats the resolved `taskRoot` and rejects it if the path does not exist, is not a directory, or is a symbolic link before performing metadata and child-directory checks.
- Added a regression test `preflight rejects symlinked bootstrap task root` to `tests/install.test.js` that creates a symlinked task root and verifies `preflight --bootstrap` fails and does not write `preflight-goal.json` into the symlink target.
- Preserved the existing metadata and child-directory validation and error reporting behavior when the task root is a normal directory.

### Testing
- Ran syntax checks with `node --check lib/bootstrap.cjs` and `node --check tests/install.test.js`, both succeeded.
- Ran the focused installer test with `node --test tests/install.test.js --test-name-pattern "preflight rejects symlinked bootstrap task root"`, and the new regression test passed.
- Ran the full test suite with `npm test`; the installer suite (including the new test) passed, while unrelated pre-existing failures remain in hook-policy/schema/leakage suites and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1302147af8832697784ff98e382212)