### PR TITLE
Harden architecture drift checks against unreported implementation changes

### DIFF
--- a/lib/run.cjs
+++ b/lib/run.cjs
@@ -691,6 +691,20 @@ function semanticProgressSnapshot(manifestPath, roots) {
   return entries;
 }
 
+
+function changedImplementationPaths(beforeSnapshot, afterSnapshot) {
+  const changed = new Set();
+  for (const key of new Set([...Object.keys(beforeSnapshot || {}), ...Object.keys(afterSnapshot || {})])) {
+    if (!key.startsWith('implementation:')) continue;
+    if ((beforeSnapshot || {})[key] === (afterSnapshot || {})[key]) continue;
+    const parts = key.split(':');
+    if (parts.length >= 3) {
+      changed.add(parts.slice(2).join(':'));
+    }
+  }
+  return [...changed].sort();
+}
+
 function snapshotsEqual(left, right) {
   const leftKeys = Object.keys(left).sort();
   const rightKeys = Object.keys(right).sort();
@@ -1245,9 +1259,19 @@ function validateImplementationReportArchitecture(report, plan, skeleton) {
   }
 }
 
-function implementationReportArchitectureTickets(roots) {
+function implementationReportArchitectureTickets(roots, observedChangedPaths = null) {
   const report = readOptionalJson(path.join(roots.cleanRoot, 'implementation-report.json'));
-  if (!report || !Array.isArray(report.changed_paths) || report.changed_paths.length === 0) {
+  if (!report || !Array.isArray(report.changed_paths)) {
+    return [];
+  }
+  if (Array.isArray(observedChangedPaths)) {
+    const normalizedReported = [...new Set(report.changed_paths.map((entry) => entry?.path).filter((value) => typeof value === 'string' && value.trim() !== ''))].sort();
+    const normalizedObserved = [...new Set(observedChangedPaths.filter((value) => typeof value === 'string' && value.trim() !== ''))].sort();
+    if (normalizedReported.length !== normalizedObserved.length || normalizedReported.some((value, index) => value !== normalizedObserved[index])) {
+      return [architectureDeltaTicket('Implementation report changed paths did not match observed implementation-root file changes. Re-run clean implementation with accurate changed_paths. ')];
+    }
+  }
+  if (report.changed_paths.length === 0) {
     return [];
   }
   const context = readCleanRunContext(roots);
@@ -1282,10 +1306,10 @@ function qcArchitectureTickets(qc) {
   return [];
 }
 
-function architectureDeltaTickets(roots, qc) {
+function architectureDeltaTickets(roots, qc, observedChangedPaths = null) {
   return [
     ...qcArchitectureTickets(qc),
-    ...implementationReportArchitectureTickets(roots),
+    ...implementationReportArchitectureTickets(roots, observedChangedPaths),
   ];
 }
 
@@ -1334,7 +1358,7 @@ function inferTerminalResult(manifest, roots, selectedUnit, options = {}) {
     polish,
     coverage,
     { abstract_delta_tickets: behaviorSpecOpenQuestionTickets(roots) },
-    { abstract_delta_tickets: architectureDeltaTickets(roots, qc) },
+    { abstract_delta_tickets: architectureDeltaTickets(roots, qc, options.observedChangedPaths || null) },
     { abstract_delta_tickets: polishReviewTickets(polish, polishRequired) }
   );
 
@@ -1621,7 +1645,10 @@ async function runCleanRoom(options, context = {}) {
         terminalResult = noProgressResult(manifest);
         ledgerEntry.stop_reason = 'no-progress-detected';
       } else if (coveragePhaseRan) {
-        terminalResult = inferTerminalResult(manifest, roots, selectedUnit, { polishRequired });
+        terminalResult = inferTerminalResult(manifest, roots, selectedUnit, {
+          polishRequired,
+          observedChangedPaths: changedImplementationPaths(before, after),
+        });
         if (terminalResult) {
           ledgerEntry.stop_reason = terminalResult.result;
         }


### PR DESCRIPTION
### Motivation
- The architecture-area validation trusted `implementation-report.json` `changed_paths` exclusively, which an attacker-controllable Agent 3 can omit to bypass architecture drift checks despite controller-observed implementation-root file changes.  
- The runner already observes implementation-root snapshots for progress detection, so validation must reconcile reported paths with independently observed file deltas to avoid trusting self-reported data.

### Description
- Add `changedImplementationPaths(beforeSnapshot, afterSnapshot)` to derive observed implementation-root changed relative paths from semantic snapshots.  
- Extend `implementationReportArchitectureTickets(roots)` to accept an optional `observedChangedPaths` array and compare normalized reported paths against observed paths, returning an architecture delta ticket on mismatch.  
- Thread `observedChangedPaths` through `architectureDeltaTickets(...)` and into `inferTerminalResult(...)`, and pass the observed changed paths computed from the `before`/`after` semantic snapshots at terminal inference time.  
- Preserve existing per-path ownership validation for reported paths; this change only adds reconciliation and a mismatch guard to prevent omitted-path bypasses.

### Testing
- Ran `node --check lib/run.cjs`, which succeeded.  
- Ran `npm test`; the test run was executed and numerous suites passed, while a set of pre-existing unrelated hook-policy tests (schema/leakage reporting behaviors) remain failing in this repository and were not introduced by this change.  
- This is a minimal, behavior-preserving fix focused on closing the self-report bypass and does not modify the existing ownership validation logic for reported paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130cdb371c83268bdf53fbf9de9339)