### PR TITLE
Map container network 'off' policy to runtime 'none' for Docker/Podman

### DIFF
--- a/hooks/agent3-verification-runner.py
+++ b/hooks/agent3-verification-runner.py
@@ -384,13 +384,14 @@ def build_container_argv(
         context,
         fallback_timeout,
     )
+    runtime_network = "none" if network == "off" else network
     validate_container_mount_roots(cwd, blocked_roots)
     container_argv = [
         container_executable(backend),
         "run",
         "--rm",
         "--network",
-        network,
+        runtime_network,
         "--read-only",
         "--cap-drop",
         "ALL",

--- a/tests/hook-shell-policy.test.js
+++ b/tests/hook-shell-policy.test.js
@@ -551,7 +551,7 @@ describe('clean-room shell hook policy', () => {
     const args = fs.readFileSync(argvPath, 'utf8').trim().split('\n');
     const argAfter = (flag) => args[args.indexOf(flag) + 1];
     assert.deepEqual(args.slice(0, 2), ['run', '--rm']);
-    assert.equal(argAfter('--network'), 'off');
+    assert.equal(argAfter('--network'), 'none');
     assert.equal(argAfter('--cap-drop'), 'ALL');
     assert.equal(argAfter('--security-opt'), 'no-new-privileges');
     assert.equal(argAfter('--pids-limit'), '512');


### PR DESCRIPTION
### Motivation

- The Agent 3 container backend advertised `network: "off"` as the offline-only policy but passed that literal through to `docker run --network`, which does not disable networking and can attach to a user network named `off` instead of enforcing isolation.

### Description

- Translate the clean-room policy token `network == "off"` to the container runtime no-network value `none` when building the Docker/Podman argv in `build_container_argv`.
- Use the translated `runtime_network` value instead of the raw policy string in the `--network` argument in `hooks/agent3-verification-runner.py`.
- Update the hardened container argv test to expect `--network none` in `tests/hook-shell-policy.test.js`.

### Testing

- Ran `node --check tests/hook-shell-policy.test.js`, which completed successfully for the updated test file.
- Ran `python3 -m py_compile hooks/*.py`, which reported no syntax errors for the changed hook file.
- Ran `npm test`; the test suite executed and the shell/hook policy tests (including the Agent 3 container argv hardening test) passed, while unrelated pre-existing failures remain in the schema and leakage hook test groups (`clean-room schema hook policy` and `clean-room leakage hook policy`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130f9479d48326b8a0989e1f8e9edf)