### PR TITLE
Harden preflight goal verification path checks

### DIFF
--- a/lib/run.cjs
+++ b/lib/run.cjs
@@ -330,27 +330,30 @@ function validateTaskManifestForRun(manifest) {
   }
 }
 
-function verifyPreflightGoal(manifest, manifestDir) {
+function verifyPreflightGoal(manifest, manifestDir, roots) {
   const preflightGoalPath = resolveManifestRoot(manifest.preflight_goal_ref, manifestDir);
   if (!preflightGoalPath) {
     throw new Error('clean-room run requires task-manifest preflight_goal_ref');
+  }
+  if (!pathIsUnder(preflightGoalPath, roots.contaminatedRoot)) {
+    throw new Error('preflight goal must resolve under contaminated artifact root');
   }
   let stat;
   try {
     stat = fs.statSync(preflightGoalPath);
   } catch (err) {
     if (err?.code === 'ENOENT') {
-      throw new Error(`preflight goal not found: ${preflightGoalPath}`);
+      throw new Error('preflight goal not found');
     }
     throw err;
   }
   if (!stat.isFile()) {
-    throw new Error(`preflight goal is not a file: ${preflightGoalPath}`);
+    throw new Error('preflight goal is not a file');
   }
   const actual = fileHash(preflightGoalPath).toLowerCase();
   const expected = manifest.preflight_goal_sha256.toLowerCase();
   if (actual !== expected) {
-    throw new Error(`preflight goal sha256 mismatch: expected ${expected}, got ${actual}`);
+    throw new Error('preflight goal sha256 mismatch');
   }
 }
 
@@ -1511,8 +1514,8 @@ async function runCleanRoom(options, context = {}) {
   validateTaskManifestSchema(options.python, taskManifestPath, schemaDir);
   const manifest = readJsonFile(taskManifestPath, null);
   validateTaskManifestForRun(manifest);
-  verifyPreflightGoal(manifest, manifestDir);
   const roots = resolveRoots(manifest, manifestDir, schemaDir);
+  verifyPreflightGoal(manifest, manifestDir, roots);
   const cap = effectiveIterationCap(manifest, options);
   const agentConfigPath = options.agentCommands ? resolvePath(options.agentCommands, context.cwd || process.cwd()) : null;
   const agentConfig = agentConfigPath ? readJsonFile(agentConfigPath, null) : null;


### PR DESCRIPTION
### Motivation
- Prevent the task-manifest `preflight_goal_ref` from being used as an arbitrary-file hash/existence oracle by constraining its resolution to the contaminated artifact root. 
- Avoid denial-of-service risk from hashing attacker-controlled large files before roots and schema validation run. 
- Preserve the intended preflight integrity check while ensuring it runs after artifact roots are resolved and validated.

### Description
- Change `verifyPreflightGoal` to accept `roots` and enforce that the resolved `preflight_goal_ref` is under `roots.contaminatedRoot` before any `stat`/hash operations. 
- Move the `verifyPreflightGoal` call to after `resolveRoots()` so containment can be checked against resolved roots. 
- Remove resolved paths and actual digest values from error messages to avoid leaking file existence or hashes. 
- Keep the existing file-type check and SHA-256 verification logic, but return generic errors on not-found, non-file, or digest mismatch conditions.

### Testing
- Ran `node --check lib/run.cjs` which succeeded. 
- Ran the full test suite with `npm test`; the suite executed and many tests passed but existing unrelated failures in schema/hook-policy and leakage-scanner tests were observed. 
- Performed local checks to ensure the new `verifyPreflightGoal` call site compiles and the runtime invocation order now resolves roots before hashing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130f95999c832681297f1a8d9ffe6b)