### PR TITLE
Validate root separation for clean-room run manifests

### DIFF
--- a/lib/run.cjs
+++ b/lib/run.cjs
@@ -259,6 +259,15 @@ function resolveRoots(manifest, manifestDir, schemaDir) {
   if (!cleanRoot) throw new Error('task manifest must provide a clean artifact root');
   if (implementationRoots.length === 0) throw new Error('task manifest must provide at least one implementation root');
 
+  validateRootSeparation({
+    sourceRoots,
+    contaminatedRoots: [contaminatedRoot],
+    cleanRoots: [cleanRoot],
+    implementationRoots,
+    allowedReadRoots,
+    schemaRoots: [schemaDir],
+  });
+
   return {
     sourceRoots,
     contaminatedRoot,
@@ -267,6 +276,33 @@ function resolveRoots(manifest, manifestDir, schemaDir) {
     allowedReadRoots,
     schemaDir,
   };
+}
+
+function assertNoRootOverlap(leftRoots, rightRoots, message) {
+  for (const left of leftRoots) {
+    for (const right of rightRoots) {
+      if (pathsOverlap(left, right)) {
+        throw new Error(message);
+      }
+    }
+  }
+}
+
+function pathsOverlap(left, right) {
+  return pathIsUnder(left, right) || pathIsUnder(right, left);
+}
+
+function validateRootSeparation(roots) {
+  assertNoRootOverlap(roots.sourceRoots, roots.cleanRoots, 'source roots and clean roots must be separate');
+  assertNoRootOverlap(roots.sourceRoots, roots.contaminatedRoots, 'source roots and contaminated artifact roots must be separate');
+  assertNoRootOverlap(roots.sourceRoots, roots.implementationRoots, 'source roots and implementation roots must be separate');
+  assertNoRootOverlap(roots.cleanRoots, roots.contaminatedRoots, 'clean roots and contaminated artifact roots must be separate');
+  assertNoRootOverlap(roots.cleanRoots, roots.implementationRoots, 'clean roots and implementation roots must be separate');
+  assertNoRootOverlap(roots.contaminatedRoots, roots.implementationRoots, 'contaminated artifact roots and implementation roots must be separate');
+  assertNoRootOverlap(roots.allowedReadRoots, roots.sourceRoots, 'allowed clean read roots must not expose source roots');
+  assertNoRootOverlap(roots.schemaRoots, roots.sourceRoots, 'schema directory must be separate from source roots');
+  assertNoRootOverlap(roots.schemaRoots, roots.cleanRoots, 'schema directory must be separate from clean roots');
+  assertNoRootOverlap(roots.schemaRoots, roots.implementationRoots, 'schema directory must be separate from implementation roots');
 }
 
 function effectiveRoots(manifest, field, manifestDir) {

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -1570,4 +1570,20 @@ describe('clean-room run command', () => {
     assert.equal(ledger.iterations[0].phases[1].role, 'clean-polish-reviewer');
     assert.equal(ledger.iterations[0].phases[1].session_brief_ref, polishBrief);
   });
+
+  test('run rejects overlapping source and contaminated roots', () => {
+    const workspace = baseWorkspace('clean-room-run-overlap-source-contaminated');
+    const manifest = readJson(workspace.manifestPath);
+    manifest.artifact_paths.contaminated_artifacts = workspace.source;
+    manifest.artifact_paths.contaminated_artifact_roots = [workspace.source];
+    manifest.initialization_snapshot.effective_roots.contaminated_artifact_roots = [workspace.source];
+    writeJson(workspace.manifestPath, manifest);
+
+    const result = runCli(['run', '--task-manifest', workspace.manifestPath, '--dry-run']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /source roots and contaminated artifact roots must be separate/);
+    assert.equal(fs.existsSync(path.join(workspace.source, '.clean-room-run.lock')), false);
+    assert.equal(fs.existsSync(path.join(workspace.source, 'controller-run-ledger.json')), false);
+    assert.equal(fs.existsSync(path.join(workspace.source, 'clean-room-result.json')), false);
+  });
 });


### PR DESCRIPTION
### Motivation
- The runner previously accepted artifact roots from the task manifest without enforcing clean/source/contaminated/implementation separation, which allowed a malicious manifest to cause the runner to create locks and write controller artifacts into source or clean roots.
- Enforce the same root-boundary checks the hook policy expects before any filesystem mutation or stage execution to preserve the clean-room trust boundary.

### Description
- Add early root-separation validation in `resolveRoots()` inside `lib/run.cjs` by calling a new `validateRootSeparation()` helper immediately after manifest root resolution.
- Implement `validateRootSeparation()`, `assertNoRootOverlap()`, and `pathsOverlap()` in `lib/run.cjs` and use `pathIsUnder()` to detect overlapping roots and throw policy-consistent error messages (e.g., `source roots and contaminated artifact roots must be separate`).
- Export no other behavioral changes; this is a guard that rejects invalid manifests before creating lock dirs or writing `controller-run-ledger.json` / `clean-room-result.json`.
- Add a regression test in `tests/run.test.js` that mutates the fixture manifest so the contaminated root equals a source root and asserts `clean-room-skill run --dry-run` fails with the expected separation error and that no lock/ledger/result files were created.

### Testing
- Performed syntax checks with `node --check lib/run.cjs bin/install.js` and `node --check tests/run.test.js`, both succeeded.
- Verified the regression behavior via a targeted CLI PoC that constructs a manifest with overlapping source/contaminated roots and ran `node bin/install.js run --task-manifest <manifest> --dry-run`, which exited nonzero and printed `source roots and contaminated artifact roots must be separate` as expected.
- Ran `node --test tests/run.test.js` / `npm test` in this execution environment but the full test runner did not complete here due to environment execution limits; the targeted CLI verification and syntax checks above confirm the regression and guard behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130f94a2308326ac462103c341ad5f)