### PR TITLE
Reject symlinked installer target roots

### DIFF
--- a/lib/fs-utils.cjs
+++ b/lib/fs-utils.cjs
@@ -73,6 +73,10 @@ function assertManagedPath(root, relPath) {
     throw new Error(`invalid relative path: ${relPath}`);
   }
   const rootPath = path.resolve(root);
+  const rootStat = lstatIfExists(rootPath);
+  if (rootStat?.isSymbolicLink()) {
+    throw new Error(`managed install root must not be a symlink: ${rootPath}`);
+  }
   const fullPath = resolveInside(rootPath, normalized);
   const rootRealPath = fs.existsSync(rootPath) ? fs.realpathSync(rootPath) : rootPath;
   const parts = normalized.split('/');

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -1654,6 +1654,19 @@ describe('clean-room-skill installer', () => {
     assert.equal(fs.existsSync(path.join(codexHome, 'skills', 'clean-room', 'SKILL.md')), false);
   });
 
+  test('install rejects symlinked install root', (t) => {
+    const root = tempDir('clean-room-root-symlink');
+    const realCodexHome = path.join(root, 'real-codex');
+    const linkedCodexHome = path.join(root, 'linked-codex');
+    fs.mkdirSync(realCodexHome, { recursive: true });
+    if (!symlinkDirOrSkip(t, realCodexHome, linkedCodexHome)) return;
+
+    const result = runInstall(['--codex', '--global', '--yes'], { CODEX_HOME: linkedCodexHome });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /managed install root must not be a symlink/);
+    assert.equal(fs.existsSync(path.join(realCodexHome, 'skills', 'clean-room', 'SKILL.md')), false);
+  });
+
   test('uninstall removes only managed files and clean-room hooks', () => {
     const root = tempDir('clean-room-uninstall');
     const claudeHome = path.join(root, 'config');


### PR DESCRIPTION
### Motivation
- The installer resolved install roots lexically and allowed a project-local runtime directory to be a symlink, which could redirect managed writes outside the intended target and corrupt other user directories. 
- The change ensures installs fail closed when the chosen `targetRoot` is a symlink to prevent unexpected cross-directory mutations.

### Description
- Add a root-level symlink guard to `assertManagedPath` in `lib/fs-utils.cjs` that calls `lstatIfExists(rootPath)` and throws if the install `root` is a symbolic link. 
- Add a regression test `install rejects symlinked install root` to `tests/install.test.js` that simulates a symlinked `CODEX_HOME` and asserts the installer aborts and does not write managed files into the symlink target.

### Testing
- Ran `node --check lib/fs-utils.cjs` and `node --check tests/install.test.js` and both checks succeeded. 
- Ran the installer unit tests with `node --test tests/install.test.js` and `npm test`, and the full test run passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130f947cf08326b0bbafe144025d94)