### PR TITLE
Enforce max-total-bytes for visual-index by accounting bytes read

### DIFF
--- a/skills/clean-room/scripts/build_visual_index.py
+++ b/skills/clean-room/scripts/build_visual_index.py
@@ -260,7 +260,7 @@ def collect_images(
     ignore_dirs = set(DEFAULT_IGNORE_DIRS) | set(args.ignore_dir)
     images: list[dict[str, Any]] = []
     skipped_entries: list[dict[str, str]] = []
-    counters = {"skipped_count": 0, "total_bytes": 0}
+    counters = {"skipped_count": 0, "total_bytes": 0, "attempted_total_bytes": 0}
     next_image_id = 1
 
     for root in roots:
@@ -270,7 +270,7 @@ def collect_images(
         def limit_reached_reason() -> str | None:
             if len(images) >= args.max_files:
                 return "file-count-limit"
-            if counters["total_bytes"] >= args.max_total_bytes:
+            if counters["attempted_total_bytes"] >= args.max_total_bytes:
                 return "total-byte-limit"
             return None
 
@@ -347,7 +347,7 @@ def collect_images(
                 if stat.st_size > args.max_file_bytes:
                     add_skipped(skipped_entries, counters, rel, "file-byte-limit", "file")
                     continue
-                if counters["total_bytes"] + stat.st_size > args.max_total_bytes:
+                if counters["attempted_total_bytes"] + stat.st_size > args.max_total_bytes:
                     add_skipped(skipped_entries, counters, rel, "total-byte-limit", "file")
                     continue
 
@@ -367,9 +367,10 @@ def collect_images(
                 if len(data) > args.max_file_bytes:
                     add_skipped(skipped_entries, counters, rel, "file-byte-limit-after-read", "file")
                     continue
-                if counters["total_bytes"] + len(data) > args.max_total_bytes:
+                counters["attempted_total_bytes"] += len(data)
+                if counters["attempted_total_bytes"] > args.max_total_bytes:
                     add_skipped(skipped_entries, counters, rel, "total-byte-limit-after-read", "file")
-                    continue
+                    break
 
                 metadata = image_metadata(data, suffix)
                 if metadata is None:


### PR DESCRIPTION
### Motivation
- The visual indexer could exceed `--max-total-bytes` because only successfully indexed images incremented `total_bytes`, while invalid-image files were read fully and not counted against the budget. 
- This allowed an attacker-controlled contaminated evidence root with many invalid images to force excess I/O/CPU during preflight indexing. 

### Description
- Add an `attempted_total_bytes` counter and initialize it in `collect_images()` to track bytes read/attempted (file: `skills/clean-room/scripts/build_visual_index.py`).
- Switch the global stop condition and pre-read size checks to use `attempted_total_bytes` so supported-extension files are bounded before and after reads.
- Increment `attempted_total_bytes` immediately after reading a file and treat a post-read overage as `total-byte-limit-after-read`, stopping further file scanning.
- Preserve `total_bytes` semantics for accepted/indexed images and aggregate metrics to avoid changing downstream outputs.

### Testing
- Ran `python3 -m py_compile hooks/*.py skills/clean-room/scripts/*.py skills/clean-room/scripts/source_index/*.py`, which succeeded. 
- Ran the full test suite with `npm test`; many installer and hook tests passed, while some existing hook-policy/schema/leakage tests failed in this environment and are unrelated to the visual-index byte-accounting change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135e4a58408326b5ad50fed8489686)